### PR TITLE
Changes to improve Rails 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - { rvm: 1.8.7, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
     - { rvm: 1.9.2, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
     - { rvm: 2.0.0, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
+    - { rvm: 2.1.1, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
 
     # different activerecord versions
     - { rvm: 1.8.7, gemfile: gemfiles/activerecord_2_2.gemfile, env: DB=mysql    }
@@ -19,6 +20,7 @@ matrix:
     - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_0.gemfile, env: DB=mysql    }
     - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_1.gemfile, env: DB=mysql    }
     - { rvm: 1.9.3, gemfile: gemfiles/activerecord_4_0.gemfile, env: DB=mysql    }
+    - { rvm: 2.1.1, gemfile: gemfiles/activerecord_4_1.gemfile, env: DB=mysql    }
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database if not exists oauth2_test;'; fi"

--- a/Appraisals
+++ b/Appraisals
@@ -26,6 +26,10 @@ if RUBY_VERSION >= '1.9'
   appraise 'activerecord_4_0' do
     gem 'activerecord', '~> 4.0.0'
     gem 'mysql', '~> 2.9.0' if ENV['DB'] == 'mysql'
-    gem 'protected_attributes', '~> 1.0.0'
+  end
+
+  appraise 'activerecord_4_1' do
+    gem 'activerecord', '~> 4.1.0'
+    gem 'mysql', '~> 2.9.0' if ENV['DB'] == 'mysql'
   end
 end

--- a/README.rdoc
+++ b/README.rdoc
@@ -159,6 +159,8 @@ example in a Sinatra app:
   end
 
   post '/oauth/apps' do
+    # Note: The following assumes protected_attributes.  For Rails 4 and above,
+    #  use: @client = Songkick::OAuth2::Model::Client.new(params.require(:client).permit(:name, :redirect_uri))
     @client = Songkick::OAuth2::Model::Client.new(params)
     @client.save ? erb(:show_client) : erb(:new_client)
   end

--- a/gemfiles/activerecord_4_1.gemfile
+++ b/gemfiles/activerecord_4_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 4.0.0"
+gem "activerecord", "~> 4.1.0"
 gem "mysql", "~> 2.9.0"
 
 gemspec :path => "../"

--- a/lib/songkick/oauth2/model/authorization.rb
+++ b/lib/songkick/oauth2/model/authorization.rb
@@ -17,7 +17,7 @@ module Songkick
         validates_uniqueness_of :refresh_token_hash, :scope => :client_id, :allow_nil => true
         validates_uniqueness_of :access_token_hash,                        :allow_nil => true
 
-        attr_accessible nil
+        attr_accessible nil if (defined?(ActiveRecord::VERSION) && ActiveRecord::VERSION::MAJOR <= 3) || defined?(ProtectedAttributes)
 
         class << self
           private :create, :new

--- a/lib/songkick/oauth2/model/client.rb
+++ b/lib/songkick/oauth2/model/client.rb
@@ -15,7 +15,7 @@ module Songkick
         validates_presence_of   :name, :redirect_uri
         validate :check_format_of_redirect_uri
 
-        attr_accessible :name, :redirect_uri
+        attr_accessible :name, :redirect_uri if (defined?(ActiveRecord::VERSION) && ActiveRecord::VERSION::MAJOR <= 3) || defined?(ProtectedAttributes)
 
         before_create :generate_credentials
 

--- a/lib/songkick/oauth2/schema/20120828112156_songkick_oauth2_schema_original_schema.rb
+++ b/lib/songkick/oauth2/schema/20120828112156_songkick_oauth2_schema_original_schema.rb
@@ -25,7 +25,7 @@ class SongkickOauth2SchemaOriginalSchema < ActiveRecord::Migration
     add_index :oauth2_authorizations, [:client_id, :code]
     add_index :oauth2_authorizations, [:access_token_hash]
     add_index :oauth2_authorizations, [:client_id, :access_token_hash]
-    add_index :oauth2_authorizations, [:client_id, :refresh_token_hash]
+    add_index :oauth2_authorizations, [:client_id, :refresh_token_hash], :name => 'index_oauth2_authorizations_client_id_refresh_token_hash' # Name must be <= 62 chars
   end
 
   def self.down

--- a/lib/songkick/oauth2/schema/20121025180447_songkick_oauth2_schema_add_unique_indexes.rb
+++ b/lib/songkick/oauth2/schema/20121025180447_songkick_oauth2_schema_add_unique_indexes.rb
@@ -3,8 +3,14 @@ class SongkickOauth2SchemaAddUniqueIndexes < ActiveRecord::Migration
 
   def self.up
     FIELDS.each do |field|
-      remove_index :oauth2_authorizations, [:client_id, field]
-      add_index :oauth2_authorizations, [:client_id, field], :unique => true
+      if field == :refresh_token_hash
+        # This field needs a custom index name to keep the name <= 62 characters
+        remove_index :oauth2_authorizations, :name => "index_oauth2_authorizations_client_id_#{field}"
+        add_index :oauth2_authorizations, [:client_id, field], :unique => true, :name => "index_oauth2_authorizations_client_id_#{field}_u"
+      else
+        remove_index :oauth2_authorizations, [:client_id, field]
+        add_index :oauth2_authorizations, [:client_id, field], :unique => true
+      end
     end
     remove_index :oauth2_authorizations, [:access_token_hash]
     add_index :oauth2_authorizations, [:access_token_hash], :unique => true

--- a/spec/songkick/oauth2/model/client_spec.rb
+++ b/spec/songkick/oauth2/model/client_spec.rb
@@ -32,14 +32,16 @@ describe Songkick::OAuth2::Model::Client do
     @client.should_not be_valid
   end
 
-  it "cannot mass-assign client_id" do
-    @client.update_attributes(:client_id => 'foo')
-    @client.client_id.should_not == 'foo'
-  end
+  if (defined?(ActiveRecord::VERSION) && ActiveRecord::VERSION::MAJOR <= 3) || defined?(ProtectedAttributes)
+    it "cannot mass-assign client_id" do
+      @client.update_attributes(:client_id => 'foo')
+      @client.client_id.should_not == 'foo'
+    end
 
-  it "cannot mass-assign client_secret" do
-    @client.update_attributes(:client_secret => 'foo')
-    @client.client_secret.should_not == 'foo'
+    it "cannot mass-assign client_secret" do
+      @client.update_attributes(:client_secret => 'foo')
+      @client.client_secret.should_not == 'foo'
+    end
   end
 
   it "has client_id and client_secret filled in" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'bundler/setup'
 
 require 'active_record'
-require 'protected_attributes' if defined?(ActiveRecord::VERSION) && ActiveRecord::VERSION::MAJOR > 3
 
 require 'songkick/oauth2/provider'
 


### PR DESCRIPTION
The following changes enable Rails 4 support, while also maintaining compatibility with Rails 3.2+

1. Call attr_accessible only when using ActiveRecord < 4 or when using the 'protected attributes' gem
2. Rename the longest database index to allow tests to run in Rails 4
3. Update the README regarding the use of filtered params
4. Change gemspec and require statements to remove references to protected_attributes, and allow ActiveRecord > 3.2